### PR TITLE
Allowed request from client app to movie_api

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ app.post('/users',[
   });
   
   //READ: Get a list of all movies
-  app.get('/movies', passport.authenticate('jwt', { session: false}), async (req, res) => {
+  app.get('/movies', async (req, res) => {
     await Movies.find()
     .then((movies) => {
       res.status(201).json(movies);


### PR DESCRIPTION
Removed passport.authenticate('jwt', { session: false }), from the /movies endpoint. This allows movie_api-client to request to show all movies data